### PR TITLE
try to make build reproducible

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,17 @@ tasks.withType<JavaCompile>().configureEach {
     options.encoding = "UTF-8"
 }
 
+tasks.withType<AbstractArchiveTask>().configureEach {
+  isPreserveFileTimestamps = false
+  isReproducibleFileOrder = true
+  filePermissions {
+    unix("rw-r--r--")
+  }
+  dirPermissions {
+    unix("rwxr-xr-x")
+  }
+}
+
 freemarkerRoot {
     configureSourceSet(SourceSet.MAIN_SOURCE_SET_NAME) { enableTests() }
     configureSourceSet("jsp20")

--- a/osgi.bnd
+++ b/osgi.bnd
@@ -51,6 +51,11 @@ DynamicImport-Package: *
 # "Compiling against more than is required"
 Bundle-RequiredExecutionEnvironment: JavaSE-16, JavaSE-15, JavaSE-14, JavaSE-13, JavaSE-12, JavaSE-11, JavaSE-10, JavaSE-9, JavaSE-1.8
 
+# for reproducible build (see https://bnd.bndtools.org/instructions/reproducible.html 
+# and https://bnd.bndtools.org/instructions/noextraheaders.html)
+-reproducible: true
+-noextraheaders: true
+
 # Non-OSGi meta:
 Main-Class: freemarker.core.CommandLine
 Extension-name: FreeMarker

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,6 +21,10 @@ rootProject.name = "freemarker-gae"
 
 apply(from = rootDir.toPath().resolve("gradle").resolve("repositories.gradle.kts"))
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
+}
+
 dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {


### PR DESCRIPTION
- e.g. all files now have fixed timestamp of '02-01-1980 00:00'  and fixed permissions
- furthermore OSGi MANIFEST.MF has no timestamped attributes

**Before this change:**

```
unzip -l freemarker-gae-2.3.33-SNAPSHOT.jar 
Archive:  freemarker-gae-2.3.33-SNAPSHOT.jar
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  12-22-2023 19:25   META-INF/
     5935  12-22-2023 19:25   META-INF/MANIFEST.MF
    11358  10-08-2022 22:17   META-INF/LICENSE
        0  12-22-2023 19:25   freemarker/
        0  12-22-2023 19:25   freemarker/cache/
     1025  12-22-2023 19:25   freemarker/cache/AndMatcher.class

```

**After this change:**

```
unzip -l freemarker-gae-2.3.33-SNAPSHOT.jar
Archive:  freemarker-gae-2.3.33-SNAPSHOT.jar
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  02-01-1980 00:00   META-INF/
     5833  02-01-1980 00:00   META-INF/MANIFEST.MF
    11358  02-01-1980 00:00   META-INF/LICENSE
        0  02-01-1980 00:00   freemarker/
        0  02-01-1980 00:00   freemarker/cache/
     1025  02-01-1980 00:00   freemarker/cache/AndMatcher.class
```

Also there are differences in the MANIFEST.MF

<img width="1570" alt="image" src="https://github.com/chrisrueger/freemarker/assets/188422/4add2952-d387-44a4-a5ee-02fa01ec56a4">


Attached 2 files before.txt and after.txt to compare the outputs.
MANIFEST.MF is the [printable output from the jarviewer of bndtools](https://bndtools.org/manual/jareditor.html#print) which produces a nice readable output.

[after.txt](https://github.com/chrisrueger/freemarker/files/13759960/after.txt)
[before.txt](https://github.com/chrisrueger/freemarker/files/13759961/before.txt)

